### PR TITLE
Removing encoding buffer modification as it breaks UTF-8 responses.

### DIFF
--- a/hurl-mode.el
+++ b/hurl-mode.el
@@ -930,10 +930,6 @@ If `PROC-SENTINEL' is provided, then set it for the hurl process."
           (setq-local read-process-output-max (* 64 1024 1024)
                       process-adaptive-read-buffering nil)))
 
-      ;; not sure if this is entirely needed for the raw output buffer for processing
-      ;; image bytes but keeping it just in case
-      (set-process-coding-system proc 'raw-text)
-
       (when proc-sentinel
         (set-process-sentinel proc proc-sentinel))
       (set-process-filter proc #'hurl-response--verbose-filter))))


### PR DESCRIPTION
Hello,

I was struggling with an encoding issue:
<img width="718" height="718" alt="Image" src="https://github.com/user-attachments/assets/e880c7c6-50c0-4342-8301-e6b03435ad34" />

But I noticed that the problem occurs only when I run via hurl-mode, executing it via the command line doesn't generate the problem:
<img width="589" height="264" alt="Image" src="https://github.com/user-attachments/assets/b5a6e654-47b5-4b5d-a683-dceeebbfe1a0" />

Investigating the hurl-mode.el file I found this line that set the process coding system as raw-text, by removing this line the problem goes away and it seems to not generate other issues in the .hurl-response buffer.